### PR TITLE
fix: remove wrong parameter at isremoveuser

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ function isAddBudget(text) {
 }
 
 function isRemoveUser(text) {
-  return (/remove user/i.test(message.text));
+  return (/remove user/i.test(text));
 }
 
 api.on(`message`, async (message) => {


### PR DESCRIPTION
Fixed mentioned `ReferenceError` by removing wrong parameter call in `isRemoveUser` method.

Solves #8 